### PR TITLE
updated url max length to 1000 on project model

### DIFF
--- a/mcclassicsapi/models/projects.py
+++ b/mcclassicsapi/models/projects.py
@@ -7,7 +7,7 @@ class Projects(models.Model):
     gear_head = models.ForeignKey('GearHead', on_delete=models.CASCADE)
     title = models.CharField(max_length=255)
     start_date = models.DateTimeField(auto_now_add=True)
-    image = models.URLField(default=None)
+    image = models.URLField(default=None, max_length=1000)
     details = models.TextField()
     make = models.TextField()
     model = models.TextField()


### PR DESCRIPTION
updated url max length to 1000 on project model
users can now upload pictures from the web with long url's